### PR TITLE
Use named imports

### DIFF
--- a/src/web/SsoConfiguration.jsx
+++ b/src/web/SsoConfiguration.jsx
@@ -5,8 +5,7 @@ import { Row, Col, Input, Button, Alert } from "react-bootstrap";
 import SsoAuthActions from "SsoAuthActions";
 import SsoAuthStore from "SsoAuthStore";
 
-import Spinner from "components/common/Spinner";
-import PageHeader from "components/common/PageHeader";
+import { PageHeader, Spinner } from "components/common";
 import ObjectUtils from 'util/ObjectUtils';
 
 const SsoConfiguration = React.createClass({


### PR DESCRIPTION
Due to our plugin architecture, if this plugin is loaded first, it may not include the code necessary to run `ChosenSelectInput`.

By using the named import, webpack will resolved the needed files and the issue will be gone.

This is a temporary solution, we are currently rethinking our web plugin architecture.

The change should be cherry-picked into the 1.0 branch.