### PR TITLE
Add sync user roles by http header

### DIFF
--- a/src/main/java/org/graylog/plugins/auth/sso/SsoAuthConfig.java
+++ b/src/main/java/org/graylog/plugins/auth/sso/SsoAuthConfig.java
@@ -40,6 +40,8 @@ public abstract class SsoAuthConfig {
                 .autoCreateUser(true)
                 .requireTrustedProxies(true)
                 .trustedProxies(trustedProxies)
+                .rolesHeader("Roles")
+                .syncRoles(false)
                 .build();
     }
 
@@ -71,7 +73,14 @@ public abstract class SsoAuthConfig {
     @JsonProperty("default_email_domain")
     @Nullable
     public abstract String defaultEmailDomain();
+    
+    @JsonProperty("sync_roles")
+    public abstract boolean syncRoles();
 
+    @JsonProperty("roles_header")
+    @Nullable
+    public abstract String rolesHeader();
+    
     @AutoValue.Builder
     public static abstract class Builder {
         abstract SsoAuthConfig build();
@@ -99,6 +108,13 @@ public abstract class SsoAuthConfig {
 
         @JsonProperty("default_email_domain")
         public abstract Builder defaultEmailDomain(@Nullable String defaultEmailDomain);
+        
+        @JsonProperty("sync_roles")
+        public abstract Builder syncRoles(boolean syncRoles);
+        
+        @JsonProperty("roles_header")
+        public abstract Builder rolesHeader(@Nullable String rolesHeader);
+
 
     }
 }

--- a/src/web/SsoConfiguration.jsx
+++ b/src/web/SsoConfiguration.jsx
@@ -119,6 +119,19 @@ const SsoConfiguration = React.createClass({
                 </Input>
               </fieldset>
               <fieldset>
+                <legend className="col-sm-12">Role synchronization</legend>
+                <Input type="checkbox" label="Synchronize the roles of the user from the specified HTTP header"
+                       help="Enable this if Graylog should automatically synchronize the roles of the user, with that specified in the http header. Only existing roles in Graylog will be added to the user."
+                       wrapperClassName="col-sm-offset-3 col-sm-9"
+                       name="sync_roles"
+                       checked={this.state.config.sync_roles}
+                       onChange={this._bindChecked}/>
+                <Input type="text" id="roles_header" name="roles_header" labelClassName="col-sm-3"
+                       wrapperClassName="col-sm-9" placeholder="Roles header" label="Roles Header"
+                       value={this.state.config.roles_header} help="Prefix of the HTTP header, can contain a comma-separated list of roles in one header, otherwise all headers with that prefix will be recognized."
+                       onChange={this._bindValue} disabled={!this.state.config.sync_roles}/>
+              </fieldset>
+              <fieldset>
                 <legend className="col-sm-12">Store settings</legend>
                 <div className="form-group">
                   <Col sm={9} smOffset={3}>


### PR DESCRIPTION
As requested in Issue #13, I added the possibility to add a "Roles" header, that can contain comma-separated values for roles.  (e.g. for mod_auth_cas)
Furthermore, The header-name is used as a prefix, so that "roles_0", "roles_1" will also be recognized and used. (to be used with e.g. mod_mellon)