### PR TITLE
Added support to synchronize Ldap users when signin-in using the SSO plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>org.graylog.plugins</groupId>
         <artifactId>graylog-plugin-web-parent</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
         <relativePath>../graylog2-server/graylog-plugin-parent/graylog-plugin-web-parent</relativePath>
     </parent>
 
     <artifactId>graylog-plugin-auth-sso</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>
@@ -35,7 +35,7 @@
     </scm>
 
     <properties>
-        <graylog.version>2.3.0</graylog.version>
+        <graylog.version>2.4.0</graylog.version>
     </properties>
 
     <dependencies>

--- a/src/test/java/org/graylog/plugins/auth/sso/SsoAuthRealmTest.java
+++ b/src/test/java/org/graylog/plugins/auth/sso/SsoAuthRealmTest.java
@@ -22,6 +22,7 @@ import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.security.PasswordAlgorithmFactory;
 import org.graylog2.security.hashing.SHA1HashPasswordAlgorithm;
+import org.graylog2.security.realm.LdapUserAuthenticator;
 import org.graylog2.shared.security.HttpHeadersToken;
 import org.graylog2.shared.security.Permissions;
 import org.graylog2.shared.users.UserService;
@@ -67,6 +68,7 @@ public class SsoAuthRealmTest {
         final SsoAuthRealm realm = new SsoAuthRealm(userService,
                                                     configService,
                                                     mock(RoleService.class),
+                                                    mock(LdapUserAuthenticator.class),
                                                     trustedProxies);
 
         final MultivaluedStringMap headers = new MultivaluedStringMap();
@@ -111,6 +113,7 @@ public class SsoAuthRealmTest {
         final SsoAuthRealm realm = new SsoAuthRealm(userService,
                                                     configService,
                                                     roleService,
+                                                    mock(LdapUserAuthenticator.class),
                                                     Collections.emptySet());
 
         final MultivaluedStringMap headers = new MultivaluedStringMap();
@@ -152,6 +155,7 @@ public class SsoAuthRealmTest {
         final SsoAuthRealm realm = new SsoAuthRealm(userService,
                                                     configService,
                                                     roleService,
+                                                    mock(LdapUserAuthenticator.class),
                                                     Collections.emptySet());
 
         final MultivaluedStringMap headers = new MultivaluedStringMap();


### PR DESCRIPTION
This change requires graylog2-server 2.4 because of the following update: https://github.com/Graylog2/graylog2-server/commit/1e69090e305d22b4355266307b13f96f0397d754

The objective of this change is to synchronize users with Ldap when signin-in or creating a user when Ldap is enabled. This makes it possible to store user information in Ldap (email, name, roles) and use SSO only for authentication.

This change should be integrated in a 2.4-snapshot branch and be merged only once graylog 2.4 is available.