### PR TITLE
Add sync user roles by http header

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,17 @@
 This plugins adds SSO (Single Sign-On) capabilities to Graylog. It supports automatic login and user account creation based on trusted HTTP headers set by an authentication proxy.
 
 
-**Required Graylog version:** 2.2.0 and later
+**Required Graylog version:** 2.5.0 and later
+
+Version Compatibility
+---------------------
+
+| Plugin Version | Graylog Version |
+| -------------- | --------------- |
+| 2.5.x          | 2.5.x           |
+| 2.4.x          | 2.4.x           |
+| 2.3.x          | 2.3.x           |
+| 1.0.x          | >=2.1.x, <2.3.x |
 
 Version Compatibility
 ---------------------

--- a/README.md
+++ b/README.md
@@ -17,15 +17,6 @@ Version Compatibility
 | 2.3.x          | 2.3.x           |
 | 1.0.x          | >=2.1.x, <2.3.x |
 
-Version Compatibility
----------------------
-
-| Plugin Version | Graylog Version |
-| -------------- | --------------- |
-| 2.4.x          | 2.4.x           |
-| 2.3.x          | 2.3.x           |
-| 1.0.x          | >=2.1.x, <2.3.x |
-
 Installation
 ------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>org.graylog.plugins</groupId>
         <artifactId>graylog-plugin-web-parent</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.1-SNAPSHOT</version>
         <relativePath>../graylog2-server/graylog-plugin-parent/graylog-plugin-web-parent</relativePath>
     </parent>
 
     <artifactId>graylog-plugin-auth-sso</artifactId>
-    <version>2.4.3-SNAPSHOT</version>
+    <version>2.5.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>
@@ -35,7 +35,7 @@
     </scm>
 
     <properties>
-        <graylog.version>2.4.0</graylog.version>
+        <graylog.version>2.5.1-SNAPSHOT</graylog.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>org.graylog.plugins</groupId>
         <artifactId>graylog-plugin-web-parent</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>2.5.0</version>
         <relativePath>../graylog2-server/graylog-plugin-parent/graylog-plugin-web-parent</relativePath>
     </parent>
 
     <artifactId>graylog-plugin-auth-sso</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>
@@ -35,7 +35,7 @@
     </scm>
 
     <properties>
-        <graylog.version>2.5.1-SNAPSHOT</graylog.version>
+        <graylog.version>2.5.0</graylog.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/org/graylog/plugins/auth/sso/SsoAuthConfig.java
+++ b/src/main/java/org/graylog/plugins/auth/sso/SsoAuthConfig.java
@@ -40,6 +40,8 @@ public abstract class SsoAuthConfig {
                 .autoCreateUser(true)
                 .requireTrustedProxies(true)
                 .trustedProxies(trustedProxies)
+                .rolesHeader("Roles")
+                .syncRoles(false)
                 .build();
     }
 
@@ -71,7 +73,14 @@ public abstract class SsoAuthConfig {
     @JsonProperty("default_email_domain")
     @Nullable
     public abstract String defaultEmailDomain();
+    
+    @JsonProperty("sync_roles")
+    public abstract boolean syncRoles();
 
+    @JsonProperty("roles_header")
+    @Nullable
+    public abstract String rolesHeader();
+    
     @AutoValue.Builder
     public static abstract class Builder {
         abstract SsoAuthConfig build();
@@ -99,6 +108,13 @@ public abstract class SsoAuthConfig {
 
         @JsonProperty("default_email_domain")
         public abstract Builder defaultEmailDomain(@Nullable String defaultEmailDomain);
+        
+        @JsonProperty("sync_roles")
+        public abstract Builder syncRoles(boolean syncRoles);
+        
+        @JsonProperty("roles_header")
+        public abstract Builder rolesHeader(@Nullable String rolesHeader);
+
 
     }
 }

--- a/src/main/java/org/graylog/plugins/auth/sso/SsoAuthConfig.java
+++ b/src/main/java/org/graylog/plugins/auth/sso/SsoAuthConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 
 import javax.annotation.Nullable;
+import java.util.Optional;
 
 @AutoValue
 @JsonDeserialize(builder = AutoValue_SsoAuthConfig.Builder.class)
@@ -83,7 +84,17 @@ public abstract class SsoAuthConfig {
     
     @AutoValue.Builder
     public static abstract class Builder {
-        abstract SsoAuthConfig build();
+        abstract SsoAuthConfig autoBuild();
+
+        public SsoAuthConfig build() {
+            if (!syncRoles().isPresent()) {
+                // take the default values, so we can show them in the UI without having to do a migration
+                final SsoAuthConfig defaultConfig = defaultConfig(null);
+                syncRoles(defaultConfig.syncRoles());
+                rolesHeader(defaultConfig.rolesHeader());
+            }
+            return autoBuild();
+        }
 
         @JsonProperty("username_header")
         public abstract Builder usernameHeader(String usernameHeader);
@@ -111,7 +122,8 @@ public abstract class SsoAuthConfig {
         
         @JsonProperty("sync_roles")
         public abstract Builder syncRoles(boolean syncRoles);
-        
+        abstract Optional<Boolean> syncRoles();
+
         @JsonProperty("roles_header")
         public abstract Builder rolesHeader(@Nullable String rolesHeader);
 

--- a/src/main/java/org/graylog/plugins/auth/sso/SsoAuthRealm.java
+++ b/src/main/java/org/graylog/plugins/auth/sso/SsoAuthRealm.java
@@ -44,8 +44,11 @@ import javax.inject.Named;
 import javax.ws.rs.core.MultivaluedMap;
 import java.net.UnknownHostException;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class SsoAuthRealm extends AuthenticatingRealm {
     private static final Logger LOG = LoggerFactory.getLogger(SsoAuthRealm.class);
@@ -163,11 +166,58 @@ public class SsoAuthRealm extends AuthenticatingRealm {
             }
             LOG.trace("Trusted header {} set, continuing with user name {}", usernameHeader, user.getName());
 
+            if (config.syncRoles()) {
+                Optional<List<String>> rolesList = headerValues(requestHeaders, config.rolesHeader());
+                if (rolesList.isPresent()) {
+                    try {
+                        syncUserRoles(rolesList.get(), user);
+                    } catch (ValidationException e) {
+                        LOG.error(
+                                "Unable to sync roles [{}] of user {} from http header. Not logging in with http header.",
+                                rolesList.get(), user, e);
+                        return null;
+                    }
+                }
+            }
+
             ShiroSecurityContext.requestSessionCreation(true);
             return new SimpleAccount(user.getName(), null, NAME);
         }
         LOG.debug("Trusted header {} is not set.", usernameHeader);
         return null;
+    }
+
+    protected Set<String> csv(List<String> values) {
+        Set<String> uniqValues = new HashSet<>();
+        for (String csString : values) {
+            String[] valueArr = csString.split(",");
+
+            for (String value : valueArr) {
+                uniqValues.add(value.trim());
+            }
+        }
+        return uniqValues;
+    }
+
+    protected void syncUserRoles(List<String> roleCsv, User user) throws ValidationException {
+        Set<String> roleNames = csv(roleCsv);
+        Set<String> existingRoles = user.getRoleIds();
+
+        Set<String> syncedRoles = new HashSet<>();
+        for (String roleName : roleNames) {
+            if (roleService.exists(roleName)) {
+                try {
+                    Role r = roleService.load(roleName);
+                    syncedRoles.add(r.getId());
+                } catch (NotFoundException e) {
+                    LOG.error("Role {} not found, but it existed before", roleName);
+                }
+            }
+        }
+        if (existingRoles != null && !existingRoles.equals(syncedRoles)) {
+            user.setRoleIds(syncedRoles);
+            userService.save(user);
+        }
     }
 
     @VisibleForTesting
@@ -191,4 +241,15 @@ public class SsoAuthRealm extends AuthenticatingRealm {
         return Optional.ofNullable(headers.getFirst(headerName.toLowerCase()));
     }
 
+    protected Optional<List<String>> headerValues(MultivaluedMap<String, String> headers,
+            @Nullable String headerNamePrefix) {
+        if (headerNamePrefix == null) {
+            return Optional.empty();
+        }
+        Set<String> keys = headers.keySet();
+        List<String> headerValues = keys.stream().filter(key -> key.startsWith(headerNamePrefix.toLowerCase()))
+                .map(key -> headers.getFirst(key)).collect(Collectors.toList());
+
+        return Optional.ofNullable(headerValues);
+    }
 }

--- a/src/test/java/org/graylog/plugins/auth/sso/SsoAuthRealmTest.java
+++ b/src/test/java/org/graylog/plugins/auth/sso/SsoAuthRealmTest.java
@@ -20,22 +20,33 @@ import com.google.common.collect.Maps;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
 import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.database.users.User;
 import org.graylog2.security.PasswordAlgorithmFactory;
 import org.graylog2.security.hashing.SHA1HashPasswordAlgorithm;
 import org.graylog2.security.realm.LdapUserAuthenticator;
 import org.graylog2.shared.security.HttpHeadersToken;
 import org.graylog2.shared.security.Permissions;
 import org.graylog2.shared.users.UserService;
+import org.graylog2.users.RoleImpl;
 import org.graylog2.users.RoleService;
 import org.graylog2.users.UserImpl;
 import org.graylog2.utilities.IpSubnet;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.net.UnknownHostException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
+import javax.ws.rs.core.MultivaluedHashMap;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -59,6 +70,8 @@ public class SsoAuthRealmTest {
                                     .emailHeader("")
                                     .fullnameHeader("")
                                     .requireTrustedProxies(false)
+                                    .syncRoles(false)
+                                    .rolesHeader("Roles")
                                     .build());
 
         final UserService userService = mock(UserService.class);
@@ -98,6 +111,8 @@ public class SsoAuthRealmTest {
                                     .fullnameHeader(null)
                                     .requireTrustedProxies(false)
                                     .defaultEmailDomain("domain.de")
+                                    .syncRoles(false)
+                                    .rolesHeader("Roles")
                                     .build());
 
         final UserService userService = mock(UserService.class);
@@ -140,6 +155,8 @@ public class SsoAuthRealmTest {
                                     .emailHeader(null)
                                     .fullnameHeader(null)
                                     .requireTrustedProxies(false)
+                                    .syncRoles(false)
+                                    .rolesHeader("Roles")
                                     .build());
 
         final UserService userService = mock(UserService.class);
@@ -168,5 +185,81 @@ public class SsoAuthRealmTest {
         assertThat(info).isNotNull();
         verify(userService).create();
         assertThat(user.getEmail()).isEqualTo("horst@localhost");
+    }
+    
+    @Test
+    public void testHeaderValuesCsv() {
+        MultivaluedHashMap<String, String> m = new MultivaluedHashMap<>();
+        m.put("roles", Arrays.asList(new String[]{"role1, role2, role3"}));
+        m.put("roles_1", Arrays.asList(new String[]{"asdf1"}));
+        m.put("roles_2", Arrays.asList(new String[]{"asdf2"}));
+        
+        SsoAuthRealm r = new SsoAuthRealm(null, null, null, null, Collections.emptySet());
+        Optional<List<String>> s = r.headerValues(m, "Roles");
+        Set<String> actual = r.csv(s.get());
+        List<String> expected = Arrays.asList(new String[]{"role1","role2","role3","asdf1","asdf2"});
+        
+        assertEquals(actual.size(), expected.size());
+        for ( String role : expected) {
+            if ( !actual.contains(role)) {
+                fail("Role [" + role + "] expected, but not in result: " + actual);
+            }
+        }
+        
+    }
+    
+    @Test
+    public void testSyncRoles() throws Exception {
+        List<String> rolesCsv = Arrays.asList(new String[]{"role1","role2", "role3, role4"});
+        
+        User u = Mockito.spy(User.class);
+        Set<String> existingRoles = new HashSet<>();
+        
+        when(u.getRoleIds()).thenReturn(existingRoles);
+        
+        RoleService roleService = mock(RoleService.class);
+        UserService userService = mock(UserService.class);
+        
+        
+        when(roleService.exists(anyString())).thenReturn(true);
+        RoleImpl role1 = new RoleImpl();
+        role1._id = "1";
+        role1.name = "role1";
+        
+        when(roleService.load("role1")).thenReturn(role1);
+        
+        RoleImpl role2 = new RoleImpl();
+        role2._id = "2";
+        role2.name = "role2";
+        
+        when(roleService.load("role2")).thenReturn(role2);
+        
+        RoleImpl role3 = new RoleImpl();
+        role3._id = "3";
+        role3.name = "role3";
+        
+        when(roleService.load("role3")).thenReturn(role3);
+        RoleImpl role4 = new RoleImpl();
+        role4._id = "4";
+        role4.name = "role4";
+        
+        when(roleService.load("role4")).thenReturn(role4);
+        
+        Set<String> syncRoles = new HashSet<>();
+        syncRoles.add(role1._id);
+        syncRoles.add(role2._id);
+        syncRoles.add(role3._id);
+        syncRoles.add(role4._id);
+        
+        Mockito.doNothing().when(u).setRoleIds(syncRoles);
+        
+        when(userService.save(u)).thenReturn("user");
+        
+        SsoAuthRealm r = new SsoAuthRealm(userService, null, roleService, null, Collections.emptySet());
+        r.syncUserRoles(rolesCsv, u);
+        
+        verify(u).getRoleIds();
+        verify(u).setRoleIds(syncRoles);
+        verify(userService).save(u);
     }
 }

--- a/src/web/SsoConfiguration.jsx
+++ b/src/web/SsoConfiguration.jsx
@@ -124,6 +124,19 @@ const SsoConfiguration = React.createClass({
                 </Input>
               </fieldset>
               <fieldset>
+                <legend className="col-sm-12">Role synchronization</legend>
+                <Input type="checkbox" label="Synchronize the roles of the user from the specified HTTP header"
+                       help="Enable this if Graylog should automatically synchronize the roles of the user, with that specified in the http header. Only existing roles in Graylog will be added to the user."
+                       wrapperClassName="col-sm-offset-3 col-sm-9"
+                       name="sync_roles"
+                       checked={this.state.config.sync_roles}
+                       onChange={this._bindChecked}/>
+                <Input type="text" id="roles_header" name="roles_header" labelClassName="col-sm-3"
+                       wrapperClassName="col-sm-9" placeholder="Roles header" label="Roles Header"
+                       value={this.state.config.roles_header} help="Prefix of the HTTP header, can contain a comma-separated list of roles in one header, otherwise all headers with that prefix will be recognized."
+                       onChange={this._bindValue} disabled={!this.state.config.sync_roles}/>
+              </fieldset>
+              <fieldset>
                 <legend className="col-sm-12">Store settings</legend>
                 <div className="form-group">
                   <Col sm={9} smOffset={3}>

--- a/src/web/SsoConfiguration.jsx
+++ b/src/web/SsoConfiguration.jsx
@@ -126,7 +126,7 @@ const SsoConfiguration = React.createClass({
               <fieldset>
                 <legend className="col-sm-12">Role synchronization</legend>
                 <Input type="checkbox" label="Synchronize the roles of the user from the specified HTTP header"
-                       help="Enable this if Graylog should automatically synchronize the roles of the user, with that specified in the http header. Only existing roles in Graylog will be added to the user."
+                       help="Enable this if Graylog should automatically synchronize the roles of the user, with that specified in the HTTP header. Only existing roles in Graylog will be added to the user."
                        wrapperClassName="col-sm-offset-3 col-sm-9"
                        name="sync_roles"
                        checked={this.state.config.sync_roles}


### PR DESCRIPTION
As requested in Issue #13, I added the possibility to add a "Roles" header, that can contain comma-separated values for roles. (e.g. for mod_auth_cas)
Furthermore, The header-name is used as a prefix, so that "roles_0", "roles_1" will also be recognized and used. (to be used with e.g. mod_mellon)