### PR TITLE
adding a filter to check if SSO headers while session is active

### DIFF
--- a/src/main/java/org/graylog/plugins/auth/sso/HeaderRoleUtil.java
+++ b/src/main/java/org/graylog/plugins/auth/sso/HeaderRoleUtil.java
@@ -1,0 +1,86 @@
+/**
+ * This file is part of Graylog Archive.
+ *
+ * Graylog Archive is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Archive is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Archive.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.auth.sso;
+
+import org.graylog2.database.NotFoundException;
+import org.graylog2.shared.users.Role;
+import org.graylog2.users.RoleService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Encapsulating common header and role parsing.
+ */
+abstract class HeaderRoleUtil {
+    private static final Logger LOG = LoggerFactory.getLogger(HeaderRoleUtil.class);
+
+    static Optional<String> headerValue(MultivaluedMap<String, String> headers, @Nullable String headerName) {
+        if (headerName == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(headers.getFirst(headerName.toLowerCase()));
+    }
+
+    static Optional<List<String>> headerValues(MultivaluedMap<String, String> headers,
+                                                         @Nullable String headerNamePrefix) {
+        if (headerNamePrefix == null) {
+            return Optional.empty();
+        }
+        Set<String> keys = headers.keySet();
+        List<String> headerValues = keys.stream().filter(key -> key.startsWith(headerNamePrefix.toLowerCase()))
+                .map(key -> headers.getFirst(key)).collect(Collectors.toList());
+
+        return Optional.ofNullable(headerValues);
+    }
+
+    static @NotNull Set<String> csv(@NotNull List<String> values) {
+        Set<String> uniqValues = new HashSet<>();
+        for (String csString : values) {
+            String[] valueArr = csString.split(",");
+
+            for (String value : valueArr) {
+                uniqValues.add(value.trim());
+            }
+        }
+        return uniqValues;
+    }
+
+    static @NotNull Set<String> getRoleIds(RoleService roleService, @NotNull Set<String> roleNames) {
+        Set<String> roleIds = new HashSet<>();
+        for (String roleName : roleNames) {
+            if (roleService.exists(roleName)) {
+                try {
+                    Role r = roleService.load(roleName);
+                    roleIds.add(r.getId());
+                } catch (NotFoundException e) {
+                    LOG.error("Role {} not found, but it existed before", roleName);
+                }
+            }
+        }
+        return roleIds;
+    }
+
+}

--- a/src/main/java/org/graylog/plugins/auth/sso/SsoAuthModule.java
+++ b/src/main/java/org/graylog/plugins/auth/sso/SsoAuthModule.java
@@ -17,8 +17,11 @@
 package org.graylog.plugins.auth.sso;
 
 import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
 import org.graylog.plugins.auth.sso.audit.SsoAuthAuditEventTypes;
 import org.graylog2.plugin.PluginModule;
+
+import javax.ws.rs.container.DynamicFeature;
 
 /**
  * Extend the PluginModule abstract class here to add you plugin to the system.
@@ -31,5 +34,8 @@ public class SsoAuthModule extends PluginModule {
         addRestResource(SsoConfigResource.class);
         addPermissions(SsoAuthPermissions.class);
         addAuditEventTypes(SsoAuthAuditEventTypes.class);
+
+        Multibinder<Class<? extends DynamicFeature>> setBinder = jerseyDynamicFeatureBinder();
+        setBinder.addBinding().toInstance(SsoSecurityBinding.class);
     }
 }

--- a/src/main/java/org/graylog/plugins/auth/sso/SsoAuthenticationFilter.java
+++ b/src/main/java/org/graylog/plugins/auth/sso/SsoAuthenticationFilter.java
@@ -1,0 +1,136 @@
+/**
+ * This file is part of Graylog Archive.
+ *
+ * Graylog Archive is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Archive is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Archive.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.auth.sso;
+
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.session.Session;
+import org.apache.shiro.subject.Subject;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.database.users.User;
+import org.graylog2.security.realm.LdapUserAuthenticator;
+import org.graylog2.shared.users.UserService;
+import org.graylog2.users.RoleService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.graylog.plugins.auth.sso.HeaderRoleUtil.*;
+
+/**
+ * Checking the session if it still matches the user and the roles in the HTTP request SSO headers.
+ * This is necessary as {@link SsoAuthRealm} is only called at the creation of the session.
+ * <p>
+ * DESIGN DECISIONS
+ * <p>
+ * #1 This class doesn't honor the additional trust proxies. This leads to closing more session than necessary,
+ * but avoids duplicating the logic here with the danger of failing to call it identically.
+ * <p>
+ * #2 If role syncing with Graylog is activated, the first request of a session checks roles against the user database.
+ * If this matches, the contents of the role header are cached in the session and checked again if the role headers of a request change.
+ * If this doesn't match, the user is logged out and the session is terminated. In a SSO system this will trigger a re-login
+ * and a re-sync of the user roles.
+ *
+ */
+/* This needs to have a lower priority than the {@link org.graylog2.shared.security.ShiroAuthenticationFilter}
+ * so that the {@link Subject} is already populated. */
+@Priority(Priorities.AUTHENTICATION + 1)
+public class SsoAuthenticationFilter implements ContainerRequestFilter {
+    private static final Logger LOG = LoggerFactory.getLogger(SsoAuthenticationFilter.class);
+    private static final String VERIFIED_ROLES = SsoAuthenticationFilter.class.getName() + ".VERIFIED_USERS";
+
+    private final ClusterConfigService clusterConfigService;
+    private final RoleService roleService;
+    private final UserService userService;
+    private final LdapUserAuthenticator ldapAuthenticator;
+
+    @Inject
+    public SsoAuthenticationFilter(ClusterConfigService clusterConfigService, RoleService roleService, UserService userService, LdapUserAuthenticator ldapAuthenticator) {
+        this.clusterConfigService = clusterConfigService;
+        this.roleService = roleService;
+        this.userService = userService;
+        this.ldapAuthenticator = ldapAuthenticator;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext containerRequestContext) {
+
+        final SsoAuthConfig config = clusterConfigService.getOrDefault(
+                SsoAuthConfig.class,
+                SsoAuthConfig.defaultConfig(""));
+
+        Subject subject = SecurityUtils.getSubject();
+        // the subject needs to be inspected only if there is a session.
+        // If there is no session, Shiro has checked the headers on this request already
+        if (subject.getSession(false) != null) {
+            Session session = subject.getSession();
+            final String usernameHeader = config.usernameHeader();
+            final Optional<String> userNameOption = headerValue(containerRequestContext.getHeaders(), usernameHeader);
+            // is the header with the user name is present ...
+            if (userNameOption.isPresent()) {
+                String username = userNameOption.get();
+                if (!username.equals(subject.getPrincipal())) {
+                    // terminate the session and return "unauthorized" for this request
+                    LOG.warn("terminating session of {} as new user {} appears in the header", subject.getPrincipal(), username);
+                    subject.logout();
+                    throw new NotAuthorizedException(Response.status(Response.Status.UNAUTHORIZED).build());
+                }
+                if (config.syncRoles()) {
+                    Optional<List<String>> rolesList = headerValues(containerRequestContext.getHeaders(), config.rolesHeader());
+                    if (rolesList.isPresent() && !rolesList.get().equals(session.getAttribute(VERIFIED_ROLES))) {
+                        User user = null;
+                        if (ldapAuthenticator.isEnabled()) {
+                            user = ldapAuthenticator.syncLdapUser(username);
+                        }
+                        if (user == null) {
+                            user = userService.load(username);
+                        }
+                        if (user == null) {
+                            LOG.error("user {} not found",
+                                    subject.getPrincipal());
+                            subject.logout();
+                            throw new NotAuthorizedException(Response.status(Response.Status.UNAUTHORIZED).build());
+                        }
+                        Set<String> roleNames = csv(rolesList.get());
+                        Set<String> existingRoles = user.getRoleIds();
+
+                        Set<String> roleIds = getRoleIds(roleService, roleNames);
+                        if (!existingRoles.equals(roleIds)) {
+                            // terminate the session and return "unauthorized" for this request
+                            LOG.warn("terminating session of user {} as roles in user differ from roles in header ({})",
+                                    subject.getPrincipal(),
+                                    roleNames);
+                            subject.logout();
+                            throw new NotAuthorizedException(Response.status(Response.Status.UNAUTHORIZED).build());
+                        }
+                        session.setAttribute(VERIFIED_ROLES, rolesList.get());
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/graylog/plugins/auth/sso/SsoSecurityBinding.java
+++ b/src/main/java/org/graylog/plugins/auth/sso/SsoSecurityBinding.java
@@ -1,0 +1,55 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.auth.sso;
+
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresGuest;
+import org.graylog2.shared.security.ShiroSecurityBinding;
+import org.graylog2.shared.security.ShiroSecurityContextFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.FeatureContext;
+import java.lang.reflect.Method;
+
+/**
+ * Adding the {@link SsoAuthenticationFilter} to each resource that requires authentication.
+ * This is mirroring the efforts in {@link ShiroSecurityBinding}
+ */
+public class SsoSecurityBinding implements DynamicFeature {
+    private static final Logger LOG = LoggerFactory.getLogger(SsoSecurityBinding.class);
+
+    @Override
+    public void configure(ResourceInfo resourceInfo, FeatureContext context) {
+        final Class<?> resourceClass = resourceInfo.getResourceClass();
+        final Method resourceMethod = resourceInfo.getResourceMethod();
+
+        context.register(ShiroSecurityContextFilter.class);
+
+        if (resourceMethod.isAnnotationPresent(RequiresAuthentication.class) || resourceClass.isAnnotationPresent(RequiresAuthentication.class)) {
+            if (resourceMethod.isAnnotationPresent(RequiresGuest.class)) {
+                LOG.debug("Resource method {}#{} is marked as unauthenticated, skipping setting filter.", resourceClass.getCanonicalName(), resourceMethod.getName());
+            } else {
+                LOG.debug("Resource method {}#{} requires an authenticated user.", resourceClass.getCanonicalName(), resourceMethod.getName());
+                context.register(SsoAuthenticationFilter.class);
+            }
+        }
+
+    }
+}

--- a/src/test/java/org/graylog/plugins/auth/sso/HeaderRoleUtilTest.java
+++ b/src/test/java/org/graylog/plugins/auth/sso/HeaderRoleUtilTest.java
@@ -1,0 +1,51 @@
+/**
+ * This file is part of Graylog Archive.
+ *
+ * Graylog Archive is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Archive is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Archive.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.auth.sso;
+
+import org.junit.Test;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+public class HeaderRoleUtilTest {
+
+    @Test
+    public void testHeaderValuesCsv() {
+        MultivaluedHashMap<String, String> m = new MultivaluedHashMap<>();
+        m.put("roles", Arrays.asList(new String[]{"role1, role2, role3"}));
+        m.put("roles_1", Arrays.asList(new String[]{"asdf1"}));
+        m.put("roles_2", Arrays.asList(new String[]{"asdf2"}));
+
+        Optional<List<String>> s = HeaderRoleUtil.headerValues(m, "Roles");
+        Set<String> actual = HeaderRoleUtil.csv(s.get());
+        List<String> expected = Arrays.asList(new String[]{"role1","role2","role3","asdf1","asdf2"});
+
+        assertEquals(actual.size(), expected.size());
+        for ( String role : expected) {
+            if ( !actual.contains(role)) {
+                fail("Role [" + role + "] expected, but not in result: " + actual);
+            }
+        }
+
+    }
+
+}

--- a/src/test/java/org/graylog/plugins/auth/sso/SsoAuthRealmTest.java
+++ b/src/test/java/org/graylog/plugins/auth/sso/SsoAuthRealmTest.java
@@ -188,27 +188,6 @@ public class SsoAuthRealmTest {
     }
     
     @Test
-    public void testHeaderValuesCsv() {
-        MultivaluedHashMap<String, String> m = new MultivaluedHashMap<>();
-        m.put("roles", Arrays.asList(new String[]{"role1, role2, role3"}));
-        m.put("roles_1", Arrays.asList(new String[]{"asdf1"}));
-        m.put("roles_2", Arrays.asList(new String[]{"asdf2"}));
-        
-        SsoAuthRealm r = new SsoAuthRealm(null, null, null, null, Collections.emptySet());
-        Optional<List<String>> s = r.headerValues(m, "Roles");
-        Set<String> actual = r.csv(s.get());
-        List<String> expected = Arrays.asList(new String[]{"role1","role2","role3","asdf1","asdf2"});
-        
-        assertEquals(actual.size(), expected.size());
-        for ( String role : expected) {
-            if ( !actual.contains(role)) {
-                fail("Role [" + role + "] expected, but not in result: " + actual);
-            }
-        }
-        
-    }
-    
-    @Test
     public void testSyncRoles() throws Exception {
         List<String> rolesCsv = Arrays.asList(new String[]{"role1","role2", "role3, role4"});
         

--- a/src/test/java/org/graylog/plugins/auth/sso/SsoAuthenticationFilterTest.java
+++ b/src/test/java/org/graylog/plugins/auth/sso/SsoAuthenticationFilterTest.java
@@ -1,0 +1,211 @@
+/**
+ * This file is part of Graylog Archive.
+ *
+ * Graylog Archive is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Archive is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Archive.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.auth.sso;
+
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.mgt.SecurityManager;
+import org.apache.shiro.session.Session;
+import org.apache.shiro.subject.Subject;
+import org.glassfish.jersey.message.internal.MediaTypeProvider;
+import org.glassfish.jersey.message.internal.OutboundJaxrsResponse;
+import org.glassfish.jersey.message.internal.OutboundMessageContext;
+import org.graylog2.database.NotFoundException;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.database.users.User;
+import org.graylog2.security.realm.LdapUserAuthenticator;
+import org.graylog2.shared.users.Role;
+import org.graylog2.shared.users.UserService;
+import org.graylog2.users.RoleService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.RuntimeDelegate;
+import java.util.*;
+
+import static org.mockito.Mockito.*;
+
+public class SsoAuthenticationFilterTest {
+
+    private static final String USER_HEADER = "Remote-User";
+    private static final String ROLE_HEADER = "Roles";
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    private SsoAuthConfig config = SsoAuthConfig.builder()
+            .usernameHeader(USER_HEADER)
+            .autoCreateUser(false)
+            .requireTrustedProxies(false)
+            .syncRoles(true)
+            .rolesHeader(ROLE_HEADER)
+            .autoBuild();
+
+    private SsoAuthenticationFilter filter;
+    private Subject subject;
+    private MultivaluedMap<String, String> headers;
+    private ContainerRequestContext containerRequest;
+    private UserService userService;
+    private RoleService roleService;
+
+    @Before
+    public void setup() {
+        // ClusterConfigService
+        ClusterConfigService clusterConfigService = mock(ClusterConfigService.class);
+        when(clusterConfigService.getOrDefault(
+                SsoAuthConfig.class,
+                SsoAuthConfig.defaultConfig(""))).thenReturn(config);
+
+        // RoleService
+        roleService = mock(RoleService.class);
+
+        // UserService
+        userService = mock(UserService.class);
+
+        // LdapUserAuthenticator
+        LdapUserAuthenticator ldapAuthenticator = mock(LdapUserAuthenticator.class);
+
+        // SsoAuthenticationFilter = System under Test
+        filter = new SsoAuthenticationFilter(clusterConfigService, roleService, userService, ldapAuthenticator);
+
+        // SecurityManager
+        SecurityManager securityManager = mock(SecurityManager.class);
+        SecurityUtils.setSecurityManager(securityManager);
+
+        // Subject
+        subject = mock(Subject.class);
+        when(securityManager.createSubject(any())).thenReturn(subject);
+
+        // Session
+        Session session = mock(Session.class);
+        when(subject.getSession(anyBoolean())).thenReturn(session);
+        when(subject.getSession()).thenReturn(session);
+        Map<Object, Object> attributes = new HashMap<>();
+        doAnswer(invocation -> {
+            attributes.put(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(session).setAttribute(any(), any());
+        doAnswer(invocation -> attributes.get(invocation.getArgument(0))).when(session).getAttribute(any());
+
+        // ContainerRequestContext
+        containerRequest = mock(ContainerRequestContext.class);
+        headers = new MultivaluedHashMap<>();
+        when(containerRequest.getHeaders()).thenReturn(headers);
+
+        // RuntimeDelegate
+        RuntimeDelegate runtimeDelegate = mock(RuntimeDelegate.class);
+        RuntimeDelegate.setInstance(runtimeDelegate);
+        when(runtimeDelegate.createHeaderDelegate(MediaType.class)).thenReturn(new MediaTypeProvider());
+        when(runtimeDelegate.createResponseBuilder())
+                .thenAnswer(invocation -> new OutboundJaxrsResponse.Builder(new OutboundMessageContext()));
+    }
+
+    @After
+    public void cleanup() {
+        RuntimeDelegate.setInstance(null);
+        SecurityUtils.setSecurityManager(null);
+    }
+
+
+    @Test
+    public void shouldAcceptWhenSubjectNameIsMatches() {
+        // given...
+        headers.put(USER_HEADER.toLowerCase(), Collections.singletonList("horst"));
+        when(subject.getPrincipal()).thenReturn("horst");
+        User user = mock(User.class);
+        when(userService.load(matches("horst"))).thenReturn(user);
+
+        // when...
+        filter.filter(containerRequest);
+
+        // then ...
+        // ... succeeds
+    }
+
+    @Test
+    public void shouldDenyWhenSubjectNameDoesntMatch() {
+        headers.put(USER_HEADER.toLowerCase(), Collections.singletonList("horst"));
+        when(subject.getPrincipal()).thenReturn("nothorst");
+
+        // expecting...
+        exceptionRule.expect(NotAuthorizedException.class);
+
+        // when...
+        filter.filter(containerRequest);
+    }
+
+    @Test
+    public void shouldAcceptWhenRolesMatch() throws NotFoundException {
+        // given...
+        headers.put(USER_HEADER.toLowerCase(), Collections.singletonList("horst"));
+        List<String> roles = Arrays.asList("role1", "role2");
+        headers.put(ROLE_HEADER.toLowerCase(), Collections.singletonList(String.join(",", roles)));
+        when(subject.getPrincipal()).thenReturn("horst");
+        User user = mock(User.class);
+        when(userService.load(matches("horst"))).thenReturn(user);
+        mockRoles(roles, user);
+
+        // when...
+        filter.filter(containerRequest);
+        // ... call a second time to see if caching of headers
+        filter.filter(containerRequest);
+
+        // then ...
+        verify(userService, times(1)).load("horst");
+    }
+
+    @Test
+    public void shouldDenyWhenRolesNameDontMatch() throws NotFoundException {
+        // given...
+        headers.put(USER_HEADER.toLowerCase(), Collections.singletonList("horst"));
+        List<String> roles = Arrays.asList("role1", "role2");
+        headers.put(ROLE_HEADER.toLowerCase(), Collections.singletonList(String.join(",", roles.subList(0, 1))));
+        when(subject.getPrincipal()).thenReturn("horst");
+        User user = mock(User.class);
+        when(userService.load(matches("horst"))).thenReturn(user);
+        mockRoles(roles, user);
+
+        // expecting...
+        exceptionRule.expect(NotAuthorizedException.class);
+
+        // when...
+        filter.filter(containerRequest);
+    }
+
+    private void mockRoles(List<String> roles, User user) throws NotFoundException {
+        Set<String> roleIds = new HashSet<>();
+        when(user.getRoleIds()).thenReturn(roleIds);
+        for (String role : roles) {
+            String roleId = "idof_" + role;
+            roleIds.add(roleId);
+            when(roleService.exists(role)).thenReturn(true);
+            when(roleService.load(role)).thenAnswer(invocation -> {
+                Role r = mock(Role.class);
+                when(r.getId()).thenReturn(roleId);
+                return r;
+            });
+        }
+    }
+
+}


### PR DESCRIPTION
I've added a filter that checks if the relevant SSO headers change during a session. close #35 

**Concept: If the SSO headers change, the existing session is terminated and the next request will re-authenticate the user.**

Check for the user name: the SSO header is checked against the name of the principal. If it doesn't match, the session is terminated.

Check for the user roles: only active if "sync user roles" is active. On the first request with a session the headers are validated against the user's roles in the database. The validated header value is cached in the session for subsequent requests to avoid hitting LDAP/database on every request. If the validation fails, the session is terminated.

Environment used for development/testing: Graylog 2.5.1 in a docker setup as described in the manual. Chrome as a browser with a "Modify Headers" plugin installed to simulate SSO Headers. SSO Plugin installed and sync user roles active.

Test Scenario: 
* Set Header "Remote-User: admin" and "Roles: admin" 
* Open Graylog. Session created for admin, showing "admin" in upper right corner
* Change headers to "Remote-User: guest" and "Roles: admin"
* Browser will automatically refresh and show user "guest" in upper right corner
* Change headers to "Remote-User: guest" and "Roles: reader"
* Browser will automatically refresh and show reduced menu set. If you've been viewing a page that is not available to the reader role, the Graylog front end will redirect to the "Not Found" page with the ape

